### PR TITLE
Condenses multiple address fields into one

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,8 +1,8 @@
 class Location < ApplicationRecord
   has_many :call_to_actions
 
-  validates_presence_of :address, :city, :state, :zipcode
-  validate :unique_location
+  validates_presence_of :address
+  validate :unique_location, :sufficient_location_data_present
 
   private
 
@@ -16,4 +16,11 @@ class Location < ApplicationRecord
 
     errors.add(:location, 'already exists') if preexisting_location
   end
+
+  def sufficient_location_data_present
+    unless (self.city && self.state) || self.zipcode
+      errors.add(:location, 'requires city and state or zipcode')
+    end
+  end
+
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,15 +1,14 @@
 class Location < ApplicationRecord
   has_many :call_to_actions
 
-  validates_presence_of :address_line_1, :city, :state, :zipcode
+  validates_presence_of :address, :city, :state, :zipcode
   validate :unique_location
 
   private
 
   def unique_location
     preexisting_location = self.class.where(
-      address_line_1: self.address_line_1,
-      address_line_2: self.address_line_2,
+      address: self.address,
       city: self.city,
       state: self.state,
       zipcode: self.zipcode,

--- a/app/resources/v1/location_resource.rb
+++ b/app/resources/v1/location_resource.rb
@@ -1,7 +1,7 @@
 module V1
   class LocationResource < JSONAPI::Resource
-    attributes :address_line_1, :address_line_2, :city, :state, :zipcode, :notes
+    attributes :address, :city, :state, :zipcode, :notes
 
-    filters :address_line_1, :city, :state, :zipcode
+    filters :address, :city, :state, :zipcode
   end
 end

--- a/db/migrate/20170329030918_alter_locations_revise_location_fields.rb
+++ b/db/migrate/20170329030918_alter_locations_revise_location_fields.rb
@@ -1,0 +1,6 @@
+class AlterLocationsReviseLocationFields < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :locations, :address_line_2
+    rename_column :locations, :address_line_1, :address
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170321012022) do
+ActiveRecord::Schema.define(version: 20170329030918) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,14 +40,13 @@ ActiveRecord::Schema.define(version: 20170321012022) do
   end
 
   create_table "locations", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "address_line_1", limit: 1000
-    t.string   "address_line_2", limit: 1000
+    t.string   "address",    limit: 1000
     t.string   "city"
     t.string   "state"
     t.string   "zipcode"
     t.text     "notes"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,8 +19,7 @@ end
 
 25.times do |i|
   Location.create!(
-    address_line_1: "#{Random.rand(250)} #{["W","E", "N", "S"].sample}. #{Random.rand(250)} #{["St", "Ave", "Blvd"].sample}.",
-    address_line_2: ["", "Suite #{Random.rand(3000)}"].sample,
+    address: "#{Random.rand(250)} #{["W","E", "N", "S"].sample}. #{Random.rand(250)} #{["St", "Ave", "Blvd"].sample}.",
     city: ["New York", "San Francisco", "Spokane", "Dallas", "Bannock", "Baltimore", "Los Angeles"].sample,
     state: ["NY", "CA", "WA", "TX", "ID", "MD"].sample,
     zipcode: rand.to_s[2..6]

--- a/features/location.feature
+++ b/features/location.feature
@@ -5,7 +5,7 @@ Feature: Locations
 
   Scenario: Retrieve a list of locations
     Given the system contains the following locations:
-      | address_line_1    |  city     | state | zipcode |
+      | address    |  city     | state | zipcode |
       | 123 Fake Street   | Fakeville | CA    | 91666		|
       | 456 Fake Street   | Gotham    | NY    | 91133		|
       | 789 Fake Street   | Dallas    | TX    | 60612		|
@@ -13,24 +13,24 @@ Feature: Locations
     When the client sends a GET request to "/locations"
     Then the response status should be "200"
     Then the response contains three locations
-    And the response contains an "address_line_1" attribute of "123 Fake Street"
-    And the response contains an "address_line_1" attribute of "456 Fake Street"
-    And the response contains an "address_line_1" attribute of "789 Fake Street"
+    And the response contains an "address" attribute of "123 Fake Street"
+    And the response contains an "address" attribute of "456 Fake Street"
+    And the response contains an "address" attribute of "789 Fake Street"
 
   Scenario: Search for Location that already exists
     Given the system contains the following locations:
-      | address_line_1  |  city     | state | zipcode |
+      | address  |  city     | state | zipcode |
       | 123 Fake Street | Fakeville | CA    | 91666		|
       | 456 Fake Street | Gotham    | CA    | 91123		|
     Given the client sends and accepts JSON
     When the client sends a GET request to "/locations?filter[state]=CA&filter[zipcode]=91666"
     Then the response status should be "200"
     And the response contains an array with one location
-    And the response contains an "address_line_1" attribute of "123 Fake Street"
+    And the response contains an "address" attribute of "123 Fake Street"
 
   Scenario: Search for Location that does not exist
     Given the client sends and accepts JSON
-    When the client sends a GET request to "/locations?address-line-1=123fakestreet"
+    When the client sends a GET request to "/locations?address=123fakestreet"
     Then the response status should be "200"
     Then the response contains zero locations
 
@@ -42,8 +42,7 @@ Feature: Locations
        "data": {
           "type": "locations",
           "attributes": {
-             "address-line-1": "123 Fake Street",
-             "address-line-2": "Suite 1500",
+             "address": "123 Fake Street",
              "city": "San Francisco",
              "state": "CA",
              "zipcode": "12345",
@@ -55,13 +54,12 @@ Feature: Locations
     When the client sends a POST request to "/locations"
     Then the response status should be "201"
     And the response contains the following attributes:
-      | attribute 	    | type      | value             |
-      | address-line-1  | String    | 123 Fake Street   |
-      | address-line-2  | String    | Suite 1500        |
-      | city            | String    | San Francisco     |
-      | state           | String    | CA                |
-      | zipcode         | String    | 12345             |
-      | notes           | String    | Head to front desk|
+      | attribute   | type      | value             |
+      | address     | String    | 123 Fake Street   |
+      | city        | String    | San Francisco     |
+      | state       | String    | CA                |
+      | zipcode     | String    | 12345             |
+      | notes       | String    | Head to front desk|
 
   Scenario: Create a Location with minimal data
     Given the client sends and accepts JSON
@@ -71,7 +69,7 @@ Feature: Locations
       "data": {
          "type": "locations",
          "attributes": {
-            "address-line-1": "123 Fake Street",
+            "address": "123 Fake Street",
              "city": "San Francisco",
              "state": "CA",
              "zipcode": "12345"
@@ -83,8 +81,7 @@ Feature: Locations
     Then the response status should be "201"
     And the response contains the following attributes:
       | attribute 	    | type      | value             |
-      | address-line-1  | String    | 123 Fake Street   |
-      | address-line-2  | String    |                   |
+      | address         | String    | 123 Fake Street   |
       | city            | String    | San Francisco     |
       | state           | String    | CA                |
       | zipcode         | String    | 12345             |
@@ -99,7 +96,7 @@ Feature: Locations
       "data": {
          "type": "locations",
           "attributes": {
-          "address-line-1": "123 Fake Street"
+          "address": "123 Fake Street"
          }
        }
     }
@@ -109,7 +106,7 @@ Feature: Locations
 
   Scenario: Attempt to create duplicate Location
     Given the system contains the following locations:
-      | address_line_1     |  city     | state | zipcode |
+      | address     |  city     | state | zipcode |
       | 123 Fake Street    | Fakeville | CA    | 91666	 |
     Given the client sends and accepts JSON
     And the client sets the JSON request body to:
@@ -118,7 +115,7 @@ Feature: Locations
       "data": {
          "type": "locations",
           "attributes": {
-             "address-line-1": "123 Fake Street",
+             "address": "123 Fake Street",
              "city": "Fakeville",
              "state": "CA",
              "zipcode": "91666"

--- a/features/step_definitions/location_steps.rb
+++ b/features/step_definitions/location_steps.rb
@@ -1,8 +1,7 @@
 ############ helpers
 
 def validate_location(attrs)
-  expect(attrs["address-line-1"]).to be_a_kind_of(String)
-  expect(attrs["address-line-2"]).to be_a_kind_of(String) if attrs["address-line-2"]
+  expect(attrs["address"]).to be_a_kind_of(String)
   expect(attrs["city"]).to be_a_kind_of(String)
   expect(attrs["state"]).to be_a_kind_of(String)
   expect(attrs["zipcode"]).to be_a_kind_of(String)
@@ -13,8 +12,7 @@ end
 Given(/^the system contains the following locations:$/) do |table|
   table.hashes.each do |hsh|
 		Location.where(
-			address_line_1: hsh[:address_line_1],
-			address_line_2: hsh[:address_line_2],
+			address: hsh[:address],
 			city: hsh[:city],
 			state: hsh[:state],
 			zipcode: hsh[:zipcode],
@@ -25,7 +23,7 @@ end
 
 Given(/^the system contains a location with uuid "([^"]*)"$/) do |uuid|
   location = Location.where(
-    address_line_1: "123 Fake St.",
+    address: "123 Fake St.",
     city: "Fakeville",
     state: "OR",
     zipcode: "12345"

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe Location, type: :model do
   it "requires certain data attributes" do
     location = described_class.new()
     location.valid?
-    expect(location.errors[:address_line_1]).to_not be_empty
+    expect(location.errors[:address]).to_not be_empty
     expect(location.errors[:city]).to_not be_empty
     expect(location.errors[:state]).to_not be_empty
     expect(location.errors[:zipcode]).to_not be_empty
   end
 
   it "validates uniqueness of location" do
-    location_attrs = {address_line_1: "123 Fake St.",
+    location_attrs = {address: "123 Fake St.",
                       city: "Bannock",
                       state: "ID",
                       zipcode: "83234" }

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -1,13 +1,46 @@
 require 'rails_helper'
 
 RSpec.describe Location, type: :model do
-  it "requires certain data attributes" do
-    location = described_class.new()
-    location.valid?
-    expect(location.errors[:address]).to_not be_empty
-    expect(location.errors[:city]).to_not be_empty
-    expect(location.errors[:state]).to_not be_empty
-    expect(location.errors[:zipcode]).to_not be_empty
+  it "invalid when missing address" do
+    loc = described_class.new()
+    loc.valid?
+    expect(loc.errors[:address]).to be_present
+  end
+
+  it "invalid when missing city, state and zip" do
+    loc = described_class.new(address: "123 Fake St.")
+    loc.valid?
+
+    expect(loc.errors[:location]).to eq ['requires city and state or zipcode']
+  end
+
+  it "invalid with address and city" do
+    loc = described_class.new(address: "123 Fake St.",
+                              city: "Milwaukee")
+    loc.valid?
+
+    expect(loc.errors[:location]).to eq ["requires city and state or zipcode"]
+  end
+
+  it "valid with address, city, state, and zipcode" do
+    loc = described_class.new(address: "123 Fake St.",
+                              city: "Milwaukee",
+                              state: "WI",
+                              zipcode: "53172")
+    expect(loc.valid?).to be true
+  end
+
+  it "valid with address, city and state" do
+    loc = described_class.new(address: "123 Fake St.",
+                              city: "Milwaukee",
+                              state: "WI")
+    expect(loc.valid?).to be true
+  end
+
+  it "valid with address and zipcode" do
+    loc = described_class.new(address: "123 Fake St.",
+                              zipcode: "53172")
+    expect(loc.valid?).to be true
   end
 
   it "validates uniqueness of location" do
@@ -16,6 +49,11 @@ RSpec.describe Location, type: :model do
                       state: "ID",
                       zipcode: "83234" }
     described_class.create!(location_attrs)
-    expect { described_class.create!(location_attrs) }.to raise_error(ActiveRecord::RecordInvalid)
+    loc = described_class.new(location_attrs)
+
+    loc.valid?
+
+    expect(loc.errors[:location]).to eq ['already exists']
   end
+
 end


### PR DESCRIPTION
Originally, the location resource had 2 address fields (address_line_1, address_line_2).   We agreed  that was unnecessary.  This PR fixes that.

I updated the documentation so that it no longer makes references to the old column names.  See https://github.com/Ragtagteam/cta-aggregator-docs/pull/1