### PR TITLE
Location: limits state size to 2 chars

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -3,6 +3,7 @@ class Location < ApplicationRecord
 
   validates_presence_of :address
   validate :unique_location, :sufficient_location_data_present
+  validates_length_of :state, is: 2
 
   private
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -3,7 +3,7 @@ class Location < ApplicationRecord
 
   validates_presence_of :address
   validate :unique_location, :sufficient_location_data_present
-  validates_length_of :state, is: 2
+  validates_length_of :state, is: 2, if: -> { self.state }
 
   private
 

--- a/db/migrate/20170329040233_alter_locations_limit_state_length.rb
+++ b/db/migrate/20170329040233_alter_locations_limit_state_length.rb
@@ -1,0 +1,5 @@
+class AlterLocationsLimitStateLength < ActiveRecord::Migration[5.0]
+  def change
+    change_column :locations, :state, :string, limit: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170329030918) do
+ActiveRecord::Schema.define(version: 20170329040233) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 20170329030918) do
   create_table "locations", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string   "address",    limit: 1000
     t.string   "city"
-    t.string   "state"
+    t.string   "state",      limit: 2
     t.string   "zipcode"
     t.text     "notes"
     t.datetime "created_at",              null: false

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -56,4 +56,12 @@ RSpec.describe Location, type: :model do
     expect(loc.errors[:location]).to eq ['already exists']
   end
 
+  it "validates size of state abbreviation" do
+    location_attrs = { address: "123 Fake St.",
+                       city: "Bannock",
+                       state: "Idaho",
+                       zipcode: "83234" }
+    location.valid?
+    expect(location.errors[:state]).to_not be_empty
+  end
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe Location, type: :model do
                        city: "Bannock",
                        state: "Idaho",
                        zipcode: "83234" }
-    location.valid?
-    expect(location.errors[:state]).to_not be_empty
+    loc = described_class.new(location_attrs)
+    loc.valid?
+    expect(loc.errors[:state]).to be_present
   end
 end


### PR DESCRIPTION
This PR adds a little code to limit the size of the column that stores a the state name on the location resource.