### PR TITLE
App.json now seeds db after app created

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "cta-aggregator",
   "scripts": {
-    "postdeploy": "rake db:migrate",
+    "postdeploy": "bundle exec rake db:migrate db:seed",
     "test": "bundle exec rake"
   },
   "env": {


### PR DESCRIPTION
Heroku uses the App.json for when spinning up a new instance for a review app (maybe for CI too?).   This PR will ensure that the DB gets seed on Review apps.