### PR TITLE
Feature/Authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :development do
 end
 
 group :test do
+  gem 'timecop'
   gem 'rspec-rails', '3.5.2'
   gem 'cucumber-rails', '1.4.5', require: false
   gem 'database_cleaner', '1.5.3'

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem 'rails', '5.0.2'
 gem 'pg', '0.19.0'
 gem 'puma', '3.7.1'
 gem 'jsonapi-resources', '0.9.0'
+gem 'knock'
+gem 'bcrypt'
 
 group :development, :test do
   gem 'pry', '0.10.4', require: true

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'jsonapi-resources', '0.9.0'
 group :development, :test do
   gem 'pry', '0.10.4', require: true
   gem 'dotenv-rails', '2.2.0'
+  gem "pry-byebug"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     arel (7.1.4)
+    bcrypt (3.1.11)
     builder (3.2.3)
     byebug (9.0.6)
     capybara (2.12.1)
@@ -87,6 +88,11 @@ GEM
       activerecord (>= 4.1)
       concurrent-ruby
       railties (>= 4.1)
+    jwt (1.5.6)
+    knock (2.1.1)
+      bcrypt (~> 3.1)
+      jwt (~> 1.5)
+      rails (>= 4.2)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -195,10 +201,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt
   cucumber-rails (= 1.4.5)
   database_cleaner (= 1.5.3)
   dotenv-rails (= 2.2.0)
   jsonapi-resources (= 0.9.0)
+  knock
   listen (= 3.0.8)
   pg (= 0.19.0)
   pry (= 0.10.4)
@@ -216,4 +224,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.14.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,7 @@ GEM
       sprockets (>= 3.0.0)
     thor (0.19.4)
     thread_safe (0.3.6)
+    timecop (0.8.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     websocket-driver (0.6.5)
@@ -203,6 +204,7 @@ DEPENDENCIES
   simplecov (= 0.14.1)
   spring (= 2.0.1)
   spring-watcher-listen (= 2.0.1)
+  timecop
   tzinfo-data (= 1.2.2)
 
 RUBY VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,7 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     arel (7.1.4)
     builder (3.2.3)
+    byebug (9.0.6)
     capybara (2.12.1)
       addressable
       mime-types (>= 1.16)
@@ -109,6 +110,9 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.4.2)
+      byebug (~> 9.0)
+      pry (~> 0.10)
     public_suffix (2.0.5)
     puma (3.7.1)
     rack (2.0.1)
@@ -198,6 +202,7 @@ DEPENDENCIES
   listen (= 3.0.8)
   pg (= 0.19.0)
   pry (= 0.10.4)
+  pry-byebug
   puma (= 3.7.1)
   rails (= 5.0.2)
   rspec-rails (= 3.5.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::API
   include JSONAPI::ActsAsResourceController
+  include Knock::Authenticable
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,8 @@
 class ApplicationController < ActionController::API
   include JSONAPI::ActsAsResourceController
   include Knock::Authenticable
+
+  def context
+    { current_user: current_user }
+  end
 end

--- a/app/controllers/v1/call_scripts_controller.rb
+++ b/app/controllers/v1/call_scripts_controller.rb
@@ -1,5 +1,6 @@
 module V1
   class CallScriptsController < ApplicationController
+    before_action :authenticate_user, except: [:show, :index]
 
   end
 end

--- a/app/controllers/v1/contacts_controller.rb
+++ b/app/controllers/v1/contacts_controller.rb
@@ -1,5 +1,6 @@
 module V1
   class ContactsController < ApplicationController
+    before_action :authenticate_user, except: [:show, :index]
 
   end
 end

--- a/app/controllers/v1/ctas_controller.rb
+++ b/app/controllers/v1/ctas_controller.rb
@@ -1,5 +1,6 @@
 module V1
   class CtasController < ApplicationController
+    before_action :authenticate_user, except: [:show, :index]
 
   end
 end

--- a/app/controllers/v1/locations_controller.rb
+++ b/app/controllers/v1/locations_controller.rb
@@ -1,5 +1,6 @@
 module V1
   class LocationsController < ApplicationController
+    before_action :authenticate_user, except: [:show, :index]
 
   end
 end

--- a/app/controllers/v1/user_token_controller.rb
+++ b/app/controllers/v1/user_token_controller.rb
@@ -1,0 +1,14 @@
+module V1
+  class UserTokenController < Knock::AuthTokenController
+    private
+
+    def auth_params
+      token = TokenRequest.new(request)
+
+      # NOTE: Knock wants you to get your token using a username and password
+      # from a post body. This is bad from a security standpoint, so instead we
+      # grab it from the request headers. See lib/token_request.rb for details.
+      { email: token.key, password: token.secret }
+    end
+  end
+end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -17,5 +17,4 @@ class Contact < ApplicationRecord
   def downcase_email
     self.email = self.email.downcase
   end
-
 end

--- a/app/models/cta.rb
+++ b/app/models/cta.rb
@@ -4,6 +4,7 @@ class CTA < ApplicationRecord
   belongs_to :contact, optional: true
   belongs_to :location, optional: true
   belongs_to :call_script, optional: true
+  belongs_to :user, optional: true
 
   validates_presence_of :title, :description, :website, :start_at, :cta_type
   validate :validate_unique_cta, on: :create

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   has_secure_password
   has_secure_token :api_key
+
+  has_many :ctas
   validates_presence_of :email
   validates_uniqueness_of :email
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,18 @@
+class User < ApplicationRecord
+  has_secure_password
+  has_secure_token :api_key
+  validates_presence_of :email
+  validates_uniqueness_of :email
+
+  before_save :normalize_email
+
+  def self.from_token_request(request)
+    self.find_by(api_key: TokenRequest.new(request).key)
+  end
+
+  private
+
+  def normalize_email
+    self.email = self.email.downcase
+  end
+end

--- a/app/resources/v1/cta_resource.rb
+++ b/app/resources/v1/cta_resource.rb
@@ -5,6 +5,7 @@ module V1
     relationship :location, to: :one
     relationship :contact, to: :one
     relationship :call_script, to: :one
+    relationship :user, to: :one, always_include_linkage_data: true
 
     filter :upcoming, apply: -> (records, value, _options) {
       records.upcoming if value[0] == "true"
@@ -13,6 +14,10 @@ module V1
     filter :cta_type, apply: ->(records, value, _options) {
       records.where(action_type: CTA::CTA_TYPES[value[0].to_sym])
     }
+
+    before_save do
+      @model.user_id = context[:current_user].id if @model.new_record?
+    end
 
     def start_time
       @model.start_at.to_i

--- a/app/resources/v1/user_resource.rb
+++ b/app/resources/v1/user_resource.rb
@@ -1,0 +1,6 @@
+module V1
+  class UserResource < JSONAPI::Resource
+    attribute :email
+    relationship :ctas, to: :many
+  end
+end

--- a/app/services/user_creation_service.rb
+++ b/app/services/user_creation_service.rb
@@ -1,0 +1,44 @@
+class SimpleLogger
+  def self.log(message)
+    puts message
+  end
+end
+
+# This is here to create users from a rake task.
+class UserCreationService
+  def initialize(params, logger=SimpleLogger, randomizer=SecureRandom)
+    @params = params
+    @logger = logger
+    @randomizer = randomizer
+  end
+
+  def save
+    saved = user.save
+    if saved
+      logger.log("Api User Created")
+      logger.log("================")
+      logger.log("API KEY: #{user.api_key}")
+      logger.log("API SECRET: #{unencrypted_api_secret}")
+      logger.log("BE SURE TO STORE THE SECRET SECURELY")
+      logger.log("WE DO NOT STORE UNENCRYPTED SECRETS")
+      logger.log("WRITE IT DOWN NOW")
+    else
+      logger.log("USER WAS INVALID:")
+      logger.log("ERRORS:")
+      logger.log("#{user.errors.full_messages.join('\n')}")
+    end
+    saved
+  end
+
+  private
+
+  def user
+    @user ||= User.new(params.merge(password: unencrypted_api_secret, password_confirmation: unencrypted_api_secret))
+  end
+
+  attr_reader :params, :logger, :randomizer
+
+  def unencrypted_api_secret
+    @unencrypted_api_secret ||= randomizer.uuid.gsub("-", "")
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,7 @@ module CTAAggregator
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.autoload_paths << Rails.root.join('lib')
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/initializers/knock.rb
+++ b/config/initializers/knock.rb
@@ -1,0 +1,59 @@
+Knock.setup do |config|
+
+  ## Expiration claim
+  ## ----------------
+  ##
+  ## How long before a token is expired. If nil is provided, token will
+  ## last forever.
+  ##
+  ## Default:
+  # config.token_lifetime = 1.day
+
+
+  ## Audience claim
+  ## --------------
+  ##
+  ## Configure the audience claim to identify the recipients that the token
+  ## is intended for.
+  ##
+  ## Default:
+  # config.token_audience = nil
+
+  ## If using Auth0, uncomment the line below
+  # config.token_audience = -> { Rails.application.secrets.auth0_client_id }
+
+  ## Signature algorithm
+  ## -------------------
+  ##
+  ## Configure the algorithm used to encode the token
+  ##
+  ## Default:
+  config.token_signature_algorithm = 'HS512'
+
+  ## Signature key
+  ## -------------
+  ##
+  ## Configure the key used to sign tokens.
+  ##
+  ## Default:
+  # config.token_secret_signature_key = -> { Rails.application.secrets.secret_key_base }
+
+  ## If using Auth0, uncomment the line below
+  # config.token_secret_signature_key = -> { JWT.base64url_decode Rails.application.secrets.auth0_client_secret }
+
+  ## Public key
+  ## ----------
+  ##
+  ## Configure the public key used to decode tokens, if required.
+  ##
+  ## Default:
+  # config.token_public_key = nil
+
+  ## Exception Class
+  ## ---------------
+  ##
+  ## Configure the exception to be used when user cannot be found.
+  ##
+  ## Default:
+  # config.not_found_exception_class_name = 'ActiveRecord::RecordNotFound'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
 
   namespace :v1, defaults: { format: 'json' } do
+    post 'authorize' => 'user_token#create'
     jsonapi_resources :ctas
     jsonapi_resources :locations
     jsonapi_resources :contacts

--- a/db/migrate/20170329014603_create_users.rb
+++ b/db/migrate/20170329014603_create_users.rb
@@ -1,0 +1,14 @@
+class CreateUsers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :users, id: :uuid do |t|
+      t.string :email, null: false
+      t.string :api_key, null: false
+      t.string :password_digest, null: false
+
+      t.timestamps
+    end
+
+    add_index :users, :email, unique: true
+    add_index :users, :api_key, unique: true
+  end
+end

--- a/db/migrate/20170419025425_add_user_id_to_ctas.rb
+++ b/db/migrate/20170419025425_add_user_id_to_ctas.rb
@@ -1,0 +1,5 @@
+class AddUserIdToCtas < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :ctas, :user, foreign_key: true, type: :uuid, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170408183935) do
+ActiveRecord::Schema.define(version: 20170419025425) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,8 +46,10 @@ ActiveRecord::Schema.define(version: 20170408183935) do
     t.uuid     "call_script_id"
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false
+    t.uuid     "user_id"
     t.index ["start_at", "action_type", "website", "title"], name: "index_ctas_on_start_at_and_action_type_and_website_and_title", unique: true, using: :btree
     t.index ["start_at"], name: "index_ctas_on_start_at", using: :btree
+    t.index ["user_id"], name: "index_ctas_on_user_id", using: :btree
   end
 
   create_table "locations", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
@@ -70,4 +72,5 @@ ActiveRecord::Schema.define(version: 20170408183935) do
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
   end
 
+  add_foreign_key "ctas", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,4 +60,14 @@ ActiveRecord::Schema.define(version: 20170408183935) do
     t.datetime "updated_at",              null: false
   end
 
+  create_table "users", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.string   "email",           null: false
+    t.string   "api_key",         null: false
+    t.string   "password_digest", null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.index ["api_key"], name: "index_users_on_api_key", unique: true, using: :btree
+    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
+  end
+
 end

--- a/features/auth.feature
+++ b/features/auth.feature
@@ -30,3 +30,77 @@ Feature: Authentication
     And the client sets an authentication header to "125:secret"
     When the client sends a POST request to "/authorize"
     Then the response status should be "404"
+
+  Scenario: JWT Authenticated Request
+    Given the system contains the following users:
+      | email           | password | password_confirmation | api_key |
+      | foo@example.com | secret   | secret                | 12345   |
+    And the client sends and accepts JSON
+    And the client sets an authorization header with a JWT for a user with email: foo@example.com
+    And the client sets the JSON request body to:
+    """
+    {
+       "data": {
+          "type": "locations",
+          "attributes": {
+             "address": "123 Fake Street",
+             "city": "San Francisco",
+             "state": "CA",
+             "zipcode": "12345",
+             "notes": "Head to front desk"
+          }
+       }
+    }
+    """
+    When the client sends a POST request to "/locations"
+    Then the response status should be "201"
+
+  @time_travel
+  Scenario: JWT Authenticated Request with an expired token
+    Given the system contains the following users:
+      | email           | password | password_confirmation | api_key |
+      | foo@example.com | secret   | secret                | 12345   |
+    And the client sends and accepts JSON
+    And the client sets an authorization header with a JWT for a user with email: foo@example.com
+    And the client sets the JSON request body to:
+    """
+    {
+       "data": {
+          "type": "locations",
+          "attributes": {
+             "address": "123 Fake Street",
+             "city": "San Francisco",
+             "state": "CA",
+             "zipcode": "12345",
+             "notes": "Head to front desk"
+          }
+       }
+    }
+    """
+    When the token expires
+    And the client sends a POST request to "/locations"
+    Then the response status should be "401"
+
+  Scenario: JWT Authenticated Request with a malformed token
+    Given the system contains the following users:
+      | email           | password | password_confirmation | api_key |
+      | foo@example.com | secret   | secret                | 12345   |
+    And the client sends and accepts JSON
+    And the client sets a malformed JWT in the authorization header
+    And the client sets the JSON request body to:
+    """
+    {
+       "data": {
+          "type": "locations",
+          "attributes": {
+             "address": "123 Fake Street",
+             "city": "San Francisco",
+             "state": "CA",
+             "zipcode": "12345",
+             "notes": "Head to front desk"
+          }
+       }
+    }
+    """
+    When the client sends a POST request to "/locations"
+    Then the response status should be "401"

--- a/features/auth.feature
+++ b/features/auth.feature
@@ -1,0 +1,32 @@
+Feature: Authentication
+  As an API consumer
+  I want to authenticate myself to the api
+  So that securely interact with the api
+
+  Scenario: Send the correct api key and token
+    Given the system contains the following users:
+      | email           | password | password_confirmation | api_key |
+      | foo@example.com | secret   | secret                | 12345   |
+    And the client sends and accepts JSON
+    And the client sets an authentication header to "12345:secret"
+    When the client sends a POST request to "/authorize"
+    Then the response status should be "201"
+    And the response contains a JWT for a user with email foo@example.com
+
+  Scenario: Send an incorrect token
+    Given the system contains the following users:
+      | email           | password | password_confirmation | api_key |
+      | foo@example.com | secret   | secret                | 12345   |
+    And the client sends and accepts JSON
+    And the client sets an authentication header to "12345:incorrect"
+    When the client sends a POST request to "/authorize"
+    Then the response status should be "404"
+
+  Scenario: Send an incorrect api key
+    Given the system contains the following users:
+      | email           | password | password_confirmation | api_key |
+      | foo@example.com | secret   | secret                | 12345   |
+    And the client sends and accepts JSON
+    And the client sets an authentication header to "125:secret"
+    When the client sends a POST request to "/authorize"
+    Then the response status should be "404"

--- a/features/call_script.feature
+++ b/features/call_script.feature
@@ -19,6 +19,7 @@ Feature: Call Scripts
 
   Scenario: Create a Script
     Given the client sends and accepts JSON
+    And the client sets a JWT in the authorization header
     And the client sets the JSON request body to:
     """
     {
@@ -39,6 +40,7 @@ Feature: Call Scripts
 
   Scenario: Create a Script with insufficient data
     Given the client sends and accepts JSON
+    And the client sets a JWT in the authorization header
     And the client sets the JSON request body to:
     """
      {
@@ -57,6 +59,7 @@ Feature: Call Scripts
       | text                                        |
       | Lorem ipsum dolor sit amet                  |
     Given the client sends and accepts JSON
+    And the client sets a JWT in the authorization header
     And the client sets the JSON request body to:
     """
     {

--- a/features/call_script.feature
+++ b/features/call_script.feature
@@ -5,7 +5,7 @@ Feature: Call Scripts
 
   Scenario: Retrieve a list of call scripts
     Given the system contains the following call scripts:
-      | text                                        | 
+      | text                                        |
       | Lorem ipsum dolor sit amet                   |
       | consectetur adipiscing elit                  |
       | sed do eiusmod tempor incididunt ut labore   |
@@ -32,7 +32,7 @@ Feature: Call Scripts
     """
     When the client sends a POST request to "/call_scripts"
     Then the response status should be "201"
-    And the response contains the following attributes: 
+    And the response contains the following attributes:
       | attribute 	 | type      | value                        |
       | text         | String    | Lorem ipsum dolor sit amet   |
 
@@ -54,7 +54,7 @@ Feature: Call Scripts
 
   Scenario: Attempt to create duplicate Script
     Given the system contains the following call scripts:
-      | text                                        | 
+      | text                                        |
       | Lorem ipsum dolor sit amet                  |
     Given the client sends and accepts JSON
     And the client sets the JSON request body to:

--- a/features/contact.feature
+++ b/features/contact.feature
@@ -13,9 +13,9 @@ Feature: Contacts
     When the client sends a GET request to "/contacts"
     Then the response status should be "200"
     Then the response contains three contacts
-    And the response contains a "name" attribute of "Fred Flintstone" 
-    And the response contains a "name" attribute of "Wilma Flintstone" 
-    And the response contains a "name" attribute of "Barney Rubble" 
+    And the response contains a "name" attribute of "Fred Flintstone"
+    And the response contains a "name" attribute of "Wilma Flintstone"
+    And the response contains a "name" attribute of "Barney Rubble"
 
   Scenario: Search for Contact that already exists by email
     Given the system contains the following contacts:
@@ -63,7 +63,7 @@ Feature: Contacts
     """
     When the client sends a POST request to "/contacts"
     Then the response status should be "201"
-    And the response contains the following attributes: 
+    And the response contains the following attributes:
       | attribute 	    | type      | value               |
       | name            | String    | Santa Claus         |
       | phone           | String    | 123456789           |
@@ -86,7 +86,7 @@ Feature: Contacts
     """
     When the client sends a POST request to "/contacts"
     Then the response status should be "201"
-    Then the response contains the following attributes: 
+    Then the response contains the following attributes:
       | attribute 	    | type      | value             |
       | name            | String    | Santa Claus       |
       | email           | String    | santa@example.com |

--- a/features/contact.feature
+++ b/features/contact.feature
@@ -47,6 +47,7 @@ Feature: Contacts
 
   Scenario: Create a Contact
     Given the client sends and accepts JSON
+    And the client sets a JWT in the authorization header
     And the client sets the JSON request body to:
     """
     {
@@ -72,6 +73,7 @@ Feature: Contacts
 
   Scenario: Create a Contact with the minimal data
     Given the client sends and accepts JSON
+    And the client sets a JWT in the authorization header
     And the client sets the JSON request body to:
     """
     {
@@ -95,6 +97,7 @@ Feature: Contacts
 
   Scenario: Create a Contact with insufficient data
     Given the client sends and accepts JSON
+    And the client sets a JWT in the authorization header
     And the client sets the JSON request body to:
     """
      {
@@ -114,6 +117,7 @@ Feature: Contacts
       | name         |  phone     | email             | website       |
       | Santa Claus  |  123456789 | santa@example.com | www.darpa.gov |
     Given the client sends and accepts JSON
+    And the client sets a JWT in the authorization header
     And the client sets the JSON request body to:
     """
     {

--- a/features/cta.feature
+++ b/features/cta.feature
@@ -75,6 +75,7 @@ Feature: CTAs
     Given the system contains a contact with uuid "cccccccc-1111-2222-3333-666666666666"
     Given the system contains a call script with uuid "dddddddd-1111-2222-3333-666666666666"
     Given the client sends and accepts JSON
+    And the client sets a JWT in the authorization header
     And the client sets the JSON request body to:
     """
     {
@@ -120,6 +121,7 @@ Feature: CTAs
 
    Scenario: Create an CTA
     Given the client sends and accepts JSON
+    And the client sets a JWT in the authorization header
     And the client sets the JSON request body to:
     """
     {
@@ -153,6 +155,7 @@ Feature: CTAs
     Given the system contains a cta with uuid "aaaaaaaa-1111-2222-3333-666666666666"
     Given the system contains a location with uuid "bbbbbbbb-1111-2222-3333-666666666666"
     Given the client sends and accepts JSON
+    And the client sets a JWT in the authorization header
     And the client sets the JSON request body to:
     """
     {
@@ -169,6 +172,7 @@ Feature: CTAs
     Given the system contains a cta with uuid "aaaaaaaa-1111-2222-3333-666666666666"
     Given the system contains a contact with uuid "cccccccc-1111-2222-3333-666666666666"
     Given the client sends and accepts JSON
+    And the client sets a JWT in the authorization header
     And the client sets the JSON request body to:
     """
      {
@@ -185,6 +189,7 @@ Feature: CTAs
     Given the system contains a cta with uuid "aaaaaaaa-1111-2222-3333-666666666666"
     Given the system contains a call script with uuid "dddddddd-1111-2222-3333-666666666666"
     Given the client sends and accepts JSON
+    And the client sets a JWT in the authorization header
     And the client sets the JSON request body to:
     """
      {
@@ -200,6 +205,7 @@ Feature: CTAs
 
   Scenario: Create a CTA with insufficient data
     Given the client sends and accepts JSON
+    And the client sets a JWT in the authorization header
     And the client sets the JSON request body to:
     """
     {
@@ -219,6 +225,7 @@ Feature: CTAs
       | title   | description | free| start_at             | end_at              | cta_type  | website         |
       | foobar  | Lorem ipsum | true| 2018-05-19 10:30:14  | 2018-05-19 14:30:14 | phone       | www.example.com |
     Given the client sends and accepts JSON
+    And the client sets a JWT in the authorization header
     And the client sets the JSON request body to:
     """
     {

--- a/features/cta.feature
+++ b/features/cta.feature
@@ -12,9 +12,9 @@ Feature: CTAs
     When the client sends a GET request to "/ctas"
     Then the response status should be "200"
     Then the response contains three ctas
-    And the response contains a "title" attribute of "CTA One" 
-    And the response contains a "title" attribute of "CTA Two" 
-    And the response contains a "title" attribute of "CTA Three" 
+    And the response contains a "title" attribute of "CTA One"
+    And the response contains a "title" attribute of "CTA Two"
+    And the response contains a "title" attribute of "CTA Three"
 
   Scenario: Retrieve a list of upcoming ctas
     Given the system contains the following ctas:
@@ -166,7 +166,7 @@ Feature: CTAs
     Then the response status should be "204"
 
    Scenario: Add contact for CTA
-    Given the system contains a cta with uuid "aaaaaaaa-1111-2222-3333-666666666666" 
+    Given the system contains a cta with uuid "aaaaaaaa-1111-2222-3333-666666666666"
     Given the system contains a contact with uuid "cccccccc-1111-2222-3333-666666666666"
     Given the client sends and accepts JSON
     And the client sets the JSON request body to:
@@ -182,7 +182,7 @@ Feature: CTAs
     Then the response status should be "204"
 
    Scenario: Add call script for CTA
-    Given the system contains a cta with uuid "aaaaaaaa-1111-2222-3333-666666666666" 
+    Given the system contains a cta with uuid "aaaaaaaa-1111-2222-3333-666666666666"
     Given the system contains a call script with uuid "dddddddd-1111-2222-3333-666666666666"
     Given the client sends and accepts JSON
     And the client sets the JSON request body to:
@@ -190,7 +190,7 @@ Feature: CTAs
      {
        "data": {
          "type": "call-scripts",
-         "id": "dddddddd-1111-2222-3333-666666666666" 
+         "id": "dddddddd-1111-2222-3333-666666666666"
        }
     }
     """

--- a/features/cta.feature
+++ b/features/cta.feature
@@ -149,7 +149,7 @@ Feature: CTAs
       | start-time      | Integer   | 1526725814        |
       | end-time        | Integer   | 1526740214        |
       | website         | String    | www.example.com   |
-      | cta-type       | String    | phone             |
+      | cta-type        | String    | phone             |
 
    Scenario: Add location for CTA
     Given the system contains a cta with uuid "aaaaaaaa-1111-2222-3333-666666666666"
@@ -223,7 +223,7 @@ Feature: CTAs
   Scenario: Attempt to create duplicate CTAs
     Given the system contains the following ctas:
       | title   | description | free| start_at             | end_at              | cta_type  | website         |
-      | foobar  | Lorem ipsum | true| 2018-05-19 10:30:14  | 2018-05-19 14:30:14 | phone       | www.example.com |
+      | foobar  | Lorem ipsum | true| 2018-05-19 10:30:14  | 2018-05-19 14:30:14 | phone     | www.example.com |
     Given the client sends and accepts JSON
     And the client sets a JWT in the authorization header
     And the client sets the JSON request body to:

--- a/features/cta.feature
+++ b/features/cta.feature
@@ -120,8 +120,11 @@ Feature: CTAs
     And the cta has a call_script_id of "dddddddd-1111-2222-3333-666666666666"
 
    Scenario: Create an CTA
-    Given the client sends and accepts JSON
-    And the client sets a JWT in the authorization header
+    Given the system contains the following users:
+      | email           | password | password_confirmation | api_key |
+      | foo@example.com | secret   | secret                | 12345   |
+    And the client sends and accepts JSON
+    And the client sets an authorization header with a JWT for a user with email: foo@example.com
     And the client sets the JSON request body to:
     """
     {
@@ -150,6 +153,7 @@ Feature: CTAs
       | end-time        | Integer   | 1526740214        |
       | website         | String    | www.example.com   |
       | cta-type        | String    | phone             |
+    And the response contains the following user relationship: foo@example.com
 
    Scenario: Add location for CTA
     Given the system contains a cta with uuid "aaaaaaaa-1111-2222-3333-666666666666"

--- a/features/location.feature
+++ b/features/location.feature
@@ -36,6 +36,7 @@ Feature: Locations
 
   Scenario: Create a Location
     Given the client sends and accepts JSON
+    And the client sets a JWT in the authorization header
     And the client sets the JSON request body to:
     """
     {
@@ -63,6 +64,7 @@ Feature: Locations
 
   Scenario: Create a Location with minimal data
     Given the client sends and accepts JSON
+    And the client sets a JWT in the authorization header
     And the client sets the JSON request body to:
     """
     {
@@ -90,6 +92,7 @@ Feature: Locations
 
   Scenario: Create a Location with insufficient data
     Given the client sends and accepts JSON
+    And the client sets a JWT in the authorization header
     And the client sets the JSON request body to:
     """
     {
@@ -109,6 +112,7 @@ Feature: Locations
       | address     |  city     | state | zipcode |
       | 123 Fake Street    | Fakeville | CA    | 91666	 |
     Given the client sends and accepts JSON
+    And the client sets a JWT in the authorization header
     And the client sets the JSON request body to:
     """
     {

--- a/features/step_definitions/auth_steps.rb
+++ b/features/step_definitions/auth_steps.rb
@@ -4,6 +4,15 @@ Given(/^the system contains the following users:$/) do |table|
   end
 end
 
+Given(/^the client sets a malformed JWT in the authorization header$/) do
+  token = "#{SecureRandom.uuid.gsub("-","_")}.#{SecureRandom.uuid.gsub("-","_")}"
+  @headers['HTTP_AUTHORIZATION'] = "Bearer #{token}"
+end
+
+When(/^the token expires$/) do
+  Timecop.freeze(DateTime.current + Knock.token_lifetime + 1.hour)
+end
+
 Then(/^the response contains a JWT for a user with email (.*?)$/) do |email|
   user = User.find_by(email: email)
   token = Knock::AuthToken.new(payload: { sub: user.id }).token

--- a/features/step_definitions/auth_steps.rb
+++ b/features/step_definitions/auth_steps.rb
@@ -1,0 +1,12 @@
+Given(/^the system contains the following users:$/) do |table|
+  table.hashes.each do |hash|
+    User.where(email: hash[:email]).first || User.create!(hash)
+  end
+end
+
+Then(/^the response contains a JWT for a user with email (.*?)$/) do |email|
+  user = User.find_by(email: email)
+  token = Knock::AuthToken.new(payload: { sub: user.id }).token
+  data = MultiJson.load(last_response.body)
+  expect(data['jwt']).to eq(token)
+end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -43,6 +43,10 @@ Given(/^the client sends and accepts JSON$/) do
   @headers = { 'ACCEPT' => "application/vnd.api+json", 'CONTENT_TYPE' => 'application/vnd.api+json'}
 end
 
+Given(/^the client sets an authentication header to "(.*?):(.*?)"$/) do |api_key, secret|
+  @headers['HTTP_AUTHORIZATION'] = "#{api_key}:#{secret}"
+end
+
 ########### when
 
 When(/^the client sets the JSON request body to:$/) do |body|

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -2,12 +2,12 @@
 
 ############# Helpers
 CAPTURE_INT = Transform(/^(?:-?\d+|zero|one|two|three|four|five|six|seven|eight|nine|ten)$/) do |v|
-    %w(zero one two three four five six seven eight nine ten).index(v) || v.to_i
+  %w(zero one two three four five six seven eight nine ten).index(v) || v.to_i
 end
 
 def value_to_type(input, expected_type)
   return nil if input.blank?
-  case 
+  case
   when expected_type.constantize == DateTime
     DateTime.parse(input)
   when expected_type.constantize == String
@@ -46,7 +46,7 @@ end
 ########### when
 
 When(/^the client sets the JSON request body to:$/) do |body|
-   @body = body
+  @body = body
 end
 
 When(/^the client sends a (GET|POST|PATCH|PUT|DELETE) request to "(.*?)"$/) do |method, path|

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -47,6 +47,12 @@ Given(/^the client sets an authentication header to "(.*?):(.*?)"$/) do |api_key
   @headers['HTTP_AUTHORIZATION'] = "#{api_key}:#{secret}"
 end
 
+Given(/^the client sets a JWT in the authorization header$/) do
+  user = User.create!(email: "foo@example.com", password: "password", password_confirmation: "password")
+  token = Knock::AuthToken.new(payload: { sub: user.id }).token
+  @headers['HTTP_AUTHORIZATION'] = "Bearer #{token}"
+end
+
 ########### when
 
 When(/^the client sets the JSON request body to:$/) do |body|

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -114,6 +114,13 @@ Then(/^the response contains the following attributes:$/) do |table|
   expect(data["attributes"]).to eq expected_attrs
 end
 
+Then(/^the response contains the following user relationship: (.*?)$/) do |email|
+  user = User.find_by!(email: email)
+
+  data = MultiJson.load(last_response.body)["data"]
+  expect(data.dig("relationships", "user", "data", "id")).to eq(user.id)
+end
+
 Then(/^the response contains an array with (#{CAPTURE_INT}) (.*?)s?$/) do |count, resource_type|
   response_body  = MultiJson.load(last_response.body)
   expect(response_body["data"].count).to eq count

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -47,6 +47,13 @@ Given(/^the client sets an authentication header to "(.*?):(.*?)"$/) do |api_key
   @headers['HTTP_AUTHORIZATION'] = "#{api_key}:#{secret}"
 end
 
+Given(/^the client sets an authorization header with a JWT for a user with email: (.*?)$/) do |email|
+  user = User.find_by(email: email)
+  raise ActiveRecord::RecordNotFound, "cannot find user with email: #{email}" unless user
+  token = Knock::AuthToken.new(payload: { sub: user.id }).token
+  @headers['HTTP_AUTHORIZATION'] = "Bearer #{token}"
+end
+
 Given(/^the client sets a JWT in the authorization header$/) do
   user = User.create!(email: "foo@example.com", password: "password", password_confirmation: "password")
   token = Knock::AuthToken.new(payload: { sub: user.id }).token
@@ -117,3 +124,8 @@ Then(/^the response status should be "([^"]*)"$/) do |status|
   expect(last_response.status).to eq status
 end
 
+############### After
+
+After('@time_travel') do
+  Timecop.return
+end

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -1,0 +1,6 @@
+namespace :user do
+  desc "creates users"
+  task :create, [:email] => :environment do |t, args|
+    UserCreationService.new(email: args[:email]).save
+  end
+end

--- a/lib/token_request.rb
+++ b/lib/token_request.rb
@@ -1,0 +1,7 @@
+class TokenRequest
+  def initialize(request)
+    @key, @secret = request.authorization.split(":")
+  end
+
+  attr_reader :key, :secret
+end

--- a/spec/lib/token_request_spec.rb
+++ b/spec/lib/token_request_spec.rb
@@ -1,0 +1,23 @@
+require "token_request"
+require "spec_helper"
+
+describe TokenRequest do
+  context "given a request with an authorization header in the format of key:secret" do
+    let(:key) { "foo" }
+    let(:secret) { "bar" }
+    let(:request) { OpenStruct.new(authorization: "#{key}:#{secret}") }
+    let(:token_request) { TokenRequest.new(request) }
+
+    describe "#key" do
+      it "is the passed in key" do
+        expect(token_request.key).to eq(key)
+      end
+    end
+
+    describe "#secret" do
+      it "is the passed in secret" do
+        expect(token_request.secret).to eq(secret)
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  let!(:password) { SecureRandom.uuid }
+  let(:user_attributes) {
+    {
+      email: "foo@example.com",
+      password: password,
+      password_confirmation: password
+    }
+  }
+  describe "#save" do
+    let(:user) { described_class.new(user_attributes) }
+    describe "api key generation" do
+      context "given a valid user" do
+        it "creates a uuid for the api key" do
+          expect(user.api_key).not_to be_present
+          user.save
+          expect(user.api_key).to be_present
+        end
+      end
+    end
+  end
+
+  describe "#authenticate" do
+    let(:user) { described_class.new(user_attributes) }
+    context "given the correct secret key" do
+      it "returns the user" do
+        expect(user.authenticate(password)).to eq(user)
+      end
+    end
+
+    context "given the incorrect secret_key" do
+      it "returns false" do
+        expect(user.authenticate("not the secret key")).to be_falsey
+      end
+    end
+  end
+
+  describe "#valid?" do
+    let(:user) { described_class.new(user_attributes) }
+    context "given the presence of an email and password" do
+      it "is valid" do
+        expect(user).to be_valid
+      end
+    end
+
+    context "given the absence of an email" do
+      let(:user) { described_class.new(user_attributes.except(:email)) }
+      it "is invalid" do
+        expect(user).not_to be_valid
+        expect(user.errors.details[:email]).to match(a_collection_including(a_hash_including(error: :blank)))
+      end
+    end
+
+    context "given the absence of an password" do
+      let(:user) { described_class.new(user_attributes.except(:password)) }
+      it "is invalid" do
+        expect(user).not_to be_valid
+        expect(user.errors.details[:password]).to match(a_collection_including(a_hash_including(error: :blank)))
+      end
+    end
+
+    context "given a pre-existing email" do
+      let(:user) { described_class.new(user_attributes) }
+
+      before do
+        described_class.create!(user_attributes)
+      end
+
+      it "is invalid" do
+        expect(user).not_to be_valid
+        expect(user.errors[:email]).to be_present
+        expect(user.errors.details[:email]).to match(a_collection_including(a_hash_including(error: :taken)))
+      end
+    end
+  end
+
+  describe ".from_token_request" do
+    let!(:user_one) { described_class.create!(user_attributes) }
+    let!(:user_two) {
+      described_class.create!(
+        user_attributes.merge(email: "footwo@example.com")
+      )
+    }
+    let(:user_one_api_key) { user_one.api_key }
+    let(:fake_user_one_request) {
+      double(authorization: "#{user_one_api_key}:it doesn't matter")
+    }
+
+    context "given a user's api key" do
+      let(:query) { User.from_token_request(fake_user_one_request) }
+      it "returns the correct user" do
+        expect(query).to eq(user_one)
+      end
+
+      it "does not return the incorrect user" do
+        expect(query).not_to eq(user_two)
+      end
+    end
+
+    context "given an invalid key" do
+      let(:fake_request) {
+        double(authorization: "something impossible:it doesn't matter")
+      }
+
+      let(:query) { User.from_token_request(fake_request) }
+      it "returns nil" do
+        expect(query).not_to be_present
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe User, type: :model do
       let(:user) { described_class.new(user_attributes.except(:email)) }
       it "is invalid" do
         expect(user).not_to be_valid
-        expect(user.errors.details[:email]).to match(a_collection_including(a_hash_including(error: :blank)))
+        expect(user).to have_error_on(:email).of_type(:blank)
       end
     end
 
@@ -57,7 +57,7 @@ RSpec.describe User, type: :model do
       let(:user) { described_class.new(user_attributes.except(:password)) }
       it "is invalid" do
         expect(user).not_to be_valid
-        expect(user.errors.details[:password]).to match(a_collection_including(a_hash_including(error: :blank)))
+        expect(user).to have_error_on(:password).of_type(:blank)
       end
     end
 
@@ -71,7 +71,7 @@ RSpec.describe User, type: :model do
       it "is invalid" do
         expect(user).not_to be_valid
         expect(user.errors[:email]).to be_present
-        expect(user.errors.details[:email]).to match(a_collection_including(a_hash_including(error: :taken)))
+        expect(user).to have_error_on(:email).of_type(:taken)
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,3 +55,13 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+RSpec::Matchers.define(:have_error_on) do |error|
+  match do |actual|
+    raise "Must be called on something that responds to errors" unless actual.respond_to?(:errors)
+    actual.errors.details[error].present? &&
+      values_match?(a_collection_including(a_hash_including(error: type)), actual.errors.details[error])
+  end
+
+  chain :of_type, :type
+end

--- a/spec/services/user_creation_service_spec.rb
+++ b/spec/services/user_creation_service_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+class QuietLogger
+  def self.log(_)
+    # ssh!
+  end
+end
+
+class FakeLogger
+  @@messages = []
+  def self.log(message)
+    @@messages << message
+  end
+
+  def self.messages
+    @@messages
+  end
+
+  def self.messages=(val)
+    @@messages = val
+  end
+
+  def self.reset!
+    @@messages = []
+  end
+end
+
+class FakeRandomizer
+  def self.uuid
+    "foo-bar"
+  end
+end
+
+describe UserCreationService, type: :service do
+  describe "#save" do
+    let(:service) { UserCreationService.new(params, QuietLogger) }
+    context "given a valid user" do
+      let(:params) { { email: "foo@example.com" } }
+
+      it "returns true" do
+        expect(service.save).to be_truthy
+      end
+
+      context "password generation" do
+        context "logging" do
+          let(:service) { UserCreationService.new(params, FakeLogger, FakeRandomizer) }
+
+          after(:each) do
+            FakeLogger.reset!
+          end
+
+          it "creates a random unencrypted api secret without dashes and logs it" do
+            service.save
+            expect(FakeLogger.messages).to include("API SECRET: foobar")
+          end
+
+          it "logs the api_key" do
+            service.save
+            expected_api_key = User.last.api_key
+            expect(FakeLogger.messages).to include("API KEY: #{expected_api_key}")
+          end
+        end
+      end
+    end
+
+    context "given an invalid user" do
+      let(:params) { { email: nil } }
+
+      it "returns false" do
+        expect(service.save).to be false
+      end
+
+      context "logging" do
+        let(:service) { UserCreationService.new(params, FakeLogger, FakeRandomizer) }
+
+        after(:each) do
+          FakeLogger.reset!
+        end
+
+        it "logs errors" do
+          service.save
+          expect(FakeLogger.messages).to include("Email can't be blank")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces the `/v1/user_token` endpoint. A successful post with an authentication header matching the following template:
```
{api_key}:{api_secret}
```

will result in a successful response of status 201, with a response body containing a valid JWT with the `sub` claim.

To support this feature, this PR adds a `User` model, which contains the following attributes:
```
email: string, unique
password_digest: string, unique, actually the api_secret
api_key: friendly id for initial authentication to the api
```

Creation of the users happens from a rake task:
```
rake user:create[email]
```