### PR TITLE
Seeds.rb: do not generate Contact emails with spaces

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,7 +14,7 @@ contacts = []
 
 50.times do 
   name = names.sample
-  contacts << Contact.create!(name: name, email: "#{name.gsub('','')}_#{SecureRandom.hex}@example.com")
+  contacts << Contact.create!(name: name, email: "#{name.gsub(' ','')}_#{SecureRandom.hex}@example.com")
 end
 
 locations = []


### PR DESCRIPTION
The original version of the Seeds file created email addresses that (accidentally) contained spaces.  This PR fixes the typo that caused that behavior.