### PR TITLE
Configures .dotenv gem

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+DATABASE_USER=postgres
+DATABASE_HOST=db

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 /log/*
 
 # Used by dotenv library to load environment variables.
-# .env
+.env
 
 ## Specific to RubyMotion:
 .dat*

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ There are three resources that are essential to this API:
 * Run test suite: `rake` (To ensure the app is in a good state)
 * Start server: `rails s`
 
+The setup script will create a `.env` file, which can be used to manage 
+environment variables.  The `.env` file is ingored by git.  Although the script
+will copy the `.env.sample` file, the sample file contains no sensitive data 
+(e.g. login credentials).  If codebase requires sensitive information for local
+development, then contact a contributor to get you set access to those additional
+environment variables.
+
 ## Tests
 
 This app uses Rspec and Cucumber for unit and integration tests.

--- a/bin/setup
+++ b/bin/setup
@@ -23,6 +23,11 @@ chdir APP_ROOT do
   #   cp 'config/database.yml.sample', 'config/database.yml'
   # end
 
+  puts "\n== Copying .env sample file =="
+  unless File.exist?('.env')
+    cp '.env.sample', '.env'
+  end
+
   puts "\n== Preparing database =="
   system! 'bin/rails db:setup'
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,8 @@ require "rails/test_unit/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+Dotenv.load(File.expand_path('/.env', __FILE__)) if File.exist?(File.expand_path('/.env', __FILE__))
+
 module CTAAggregator
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
This app had the `dotenv` gem as a dependency, but it had never actually been configured for use.  This PR 

- Loads the gem into the runtime environment when the app runs in development or test environments
- updates the setup script to create a .dotenv file if there isn't one present already.
- updates README to mention .dot env usage