### PR TITLE
Allow read-only CORS access

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'puma', '3.7.1'
 gem 'jsonapi-resources', '0.9.0'
 gem 'knock'
 gem 'bcrypt'
+gem 'rack-cors'
 
 group :development, :test do
   gem 'pry', '0.10.4', require: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,7 @@ GEM
     public_suffix (2.0.5)
     puma (3.7.1)
     rack (2.0.1)
+    rack-cors (0.4.1)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.2)
@@ -212,6 +213,7 @@ DEPENDENCIES
   pry (= 0.10.4)
   pry-byebug
   puma (= 3.7.1)
+  rack-cors
   rails (= 5.0.2)
   rspec-rails (= 3.5.2)
   simplecov (= 0.14.1)
@@ -224,4 +226,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.14.3
+   1.15.1

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,10 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'example.com'
-#
-#     resource '*',
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins '*'
+    # only allow read actions, at least for now
+    resource '*', :headers => :any, :methods => [:get, :head, :options]
+  end
+end


### PR DESCRIPTION
These changes will allow javascript on any page to fetch (not update or delete) resources from the API.

If we need to lock this down more in the future, we can:
- rate limit based on requesting IP address
- rate limit based on request origin (the domain of the page that the request is coming from)
- whitelist domains that are allowed to request from client side javascript

Allowing CORS access significantly simplifies the integration process for displaying CTAs, and is independent of backend language or technology.