### PR TITLE
Enable rack-cors  debugging outside of production

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,7 +5,7 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-Rails.application.config.middleware.insert_before 0, Rack::Cors do
+Rails.application.config.middleware.insert_before 0, Rack::Cors, :debug => !Rails.env.production?,  :logger => (-> { Rails.logger }) do
   allow do
     origins '*'
     # only allow read actions, at least for now


### PR DESCRIPTION
Enabling debugging header for rack-cors to simplify troubleshooting client-side javascript issues.