### PR TITLE
Feature/event filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This app uses Rspec for unit and integration tests.
 * How to run seed script on heroku review app?
 * Authentication
 * AdvocacyCampaign: endpoint for AdvocacyCampaign data in iCal format
-* AdvocacyCampaigns: Change `upcoming` query to be flexible, allowing querying for upcoming and past AdvocacyCampaigns
+* Events: Change `upcoming` query to be flexible, allowing querying for upcoming and past Events
 * Location: get list of AdvocacyCampaigns associated with location
 * Contacts: get list of AdvocacyCampaigns associated with contact
 * Contact: Phone number validation

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,6 +3,8 @@ class Event < ApplicationRecord
   belongs_to :location
   belongs_to :user, optional: true
 
+  scope :upcoming, -> { where("start_date >= ?", Date.today).order("start_date")  }
+
   validate :validate_uniqueness, on: [:create, :update]
 
   validates :title, :description, :browser_url, :origin_system,

--- a/app/resources/v1/event_resource.rb
+++ b/app/resources/v1/event_resource.rb
@@ -10,5 +10,9 @@ module V1
       @model.user_id = context[:current_user].id if @model.new_record?
     end
 
+    filter :upcoming, apply: -> (records, value, _options) {
+      records.upcoming if value[0] == "true"
+    }
+
   end
 end

--- a/spec/api/v1/events_spec.rb
+++ b/spec/api/v1/events_spec.rb
@@ -18,6 +18,19 @@ RSpec.describe "Events", type: :request do
       end
 
     end
+
+    it "filters for future events" do
+      past_event = create(:event, title: 'past event', start_date: 5.days.ago)
+      future_event = create(:event, title: 'welcome to the future', start_date: DateTime.now + 2.days)
+      serialized_future_event = json_resource(V1::EventResource, future_event)[:data].deep_symbolize_keys.except(:links, :relationships)
+
+      get v1_events_path, { filter: { upcoming: true } }
+
+      response_data = JSON.parse(response.body)['data']
+
+      expect(response_data.length).to eq(1)
+      expect(response_data[0].deep_symbolize_keys.except(:links, :relationships)).to eq(serialized_future_event)
+    end
   end
 
   describe "POST /v1/events" do


### PR DESCRIPTION
Prior to adopting the OSDI data model, it was possible to filter for upcoming calls to action.

This PR re-enables filtering for upcoming Events.

