### PR TITLE
When POSTing duplicate advocacy campaign, redirect to preexistnce adv…

### DIFF
--- a/app/controllers/v1/advocacy_campaigns_controller.rb
+++ b/app/controllers/v1/advocacy_campaigns_controller.rb
@@ -2,5 +2,22 @@ module V1
   class AdvocacyCampaignsController < ApplicationController
     before_action :authenticate_user, except: [:show, :index]
 
+    def create
+      existing_advocacy_campaign = AdvocacyCampaign.where(advocacy_campaign_lookup_params).first
+
+      if existing_advocacy_campaign
+        redirect_to(action: :show, id: existing_advocacy_campaign.id)
+      else
+        super
+      end
+
+    end
+
+    private
+
+    def advocacy_campaign_lookup_params
+      params.require(:data).require(:attributes).permit(:title, :browser_url)
+    end
+
   end
 end

--- a/spec/api/v1/advocacy_campaigns_spec.rb
+++ b/spec/api/v1/advocacy_campaigns_spec.rb
@@ -47,6 +47,23 @@ RSpec.describe "AdvocacyCampaigns", type: :request do
       expect(attributes).to eq(json['data']['attributes'].except('target_list'))
       expect(json['data']['attributes']['target_list']).to_not be_empty
     end
+
+    it "redirects on duplicate create" do
+      attributes = create(:advocacy_campaign).attributes.except('created_at', 'updated_at')
+      existing_id = attributes.delete('id')
+
+      params = {
+        data: {
+          type: 'advocacy_campaigns',
+          attributes: attributes,
+        }
+      }.to_json
+
+      post v1_advocacy_campaigns_path, params: params, headers: json_api_headers_with_auth
+
+      expect(response).to have_http_status(302)
+      expect(response.headers['Location']).to match(existing_id)
+    end
   end
 
 end


### PR DESCRIPTION
This PR updates the API so that the behavior seen in the Events controller is also present in the Advocacy Campaign controller.

When someone attempts to create a Event that already exists, they're redirected to the preexistent Event.

https://github.com/Ragtagteam/cta-aggregator/blob/develop/app/controllers/v1/events_controller.rb

Now we do the exact same thing for Advocacy Campaigns.
