### PR TITLE
Removes requirement for OCDID for Targets

### DIFF
--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -9,7 +9,7 @@ class Target < ApplicationRecord
   has_many :advocacy_campaign_targets
   has_many :advocacy_campaigns, through: :advocacy_campaign_targets
 
-  validates :organization, :given_name, :family_name, :ocdid,
+  validates :organization, :given_name, :family_name,
     presence: true
 
   validate :unique_target, on: [:create, :update]
@@ -22,8 +22,7 @@ class Target < ApplicationRecord
       existing_target = Target.where(
         organization: organization,
         given_name:  given_name,
-        family_name:  family_name,
-        ocdid: ocdid
+        family_name:  family_name
       ).first
 
       errors.add(:target, 'already exists') if existing_target

--- a/spec/models/target_spec.rb
+++ b/spec/models/target_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Target, type: :model do
     expect(target.errors[:organization]).to_not be_empty
     expect(target.errors[:given_name]).to_not be_empty
     expect(target.errors[:family_name]).to_not be_empty
-    expect(target.errors[:ocdid]).to_not be_empty
   end
 
   it "does not allow duplicate objects" do


### PR DESCRIPTION
This PR makes passing along the OCDID attribute optional for Targets.