### PR TITLE
Feature/revise target validations

### DIFF
--- a/app/models/advocacy_campaign.rb
+++ b/app/models/advocacy_campaign.rb
@@ -2,7 +2,7 @@ class AdvocacyCampaign < ApplicationRecord
 
   belongs_to :user, optional: true
 
-  has_many :advocacy_campaign_targets
+  has_many :advocacy_campaign_targets, dependent: :destroy
   has_many :target_list, through: :advocacy_campaign_targets, source: :target
 
   validate :validate_uniqueness, on: [:create, :update]

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -9,12 +9,18 @@ class Target < ApplicationRecord
   has_many :advocacy_campaign_targets
   has_many :advocacy_campaigns, through: :advocacy_campaign_targets
 
-  validates :organization,
-    presence: true
+  validate :organization_or_name
 
   validate :unique_target, on: [:create, :update]
 
   private
+
+    def organization_or_name
+      unless organization || (given_name && family_name)
+        errors.add(:base, 'organization or combo of given and family name required')
+      end
+
+    end
 
     def unique_target
       return if changes.empty?

--- a/spec/models/target_spec.rb
+++ b/spec/models/target_spec.rb
@@ -2,10 +2,23 @@ require 'rails_helper'
 
 RSpec.describe Target, type: :model do
 
-  it "requires certain data attributes" do
+  it "requires either organization or name" do
     target = described_class.new()
     target.valid?
-    expect(target.errors[:organization]).to_not be_empty
+    expect(target.errors[:base]).to_not be_empty
+
+    target.organization = "foobar.org"
+    target.valid?
+    expect(target.errors[:base]).to be_empty
+
+    target.organization = nil
+    target.valid?
+    expect(target.errors[:base]).to_not be_empty
+
+    target.given_name = "Foo"
+    target.family_name = "Bar"
+    target.valid?
+    expect(target.errors[:base]).to be_empty
   end
 
   it "does not allow duplicate objects" do


### PR DESCRIPTION
This PR 

- Changes validations for Target.  Previously, we required the name and organization was optional. We need to accommodate 5Call CTAs where they ask people to call an organization, e.g. "the Dept of Justice."  This PR requires the target to have either a name or an organization.
- Ensure that we destroy an AdvocacyCampaignTarget when an AdvocacyCampaign is destroyed.