### PR TITLE
Rename authentication endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 
   namespace :v1, defaults: { format: 'json' } do
-    post 'authorize' => 'user_token#create'
+    post 'authentications' => 'user_token#create'
     jsonapi_resources :advocacy_campaigns
     jsonapi_resources :targets
     jsonapi_resources :events


### PR DESCRIPTION
This PR renames the auth endpoint.  Originally, it was `/authorize`, but it didn't deal with authorization.  It simply dispenses authentications tokens, so now it's getting a  more descriptive name.

https://github.com/Ragtagteam/cta-aggregator/issues/70